### PR TITLE
Patch 1

### DIFF
--- a/src/scripts/App.js
+++ b/src/scripts/App.js
@@ -30,7 +30,7 @@ export default class App {
 		window.addEventListener('resize', this.resize.bind(this));
 		window.addEventListener('keyup', this.keyup.bind(this));
 		
-		const el = this.webgl.renderer.domElement; 
+		const el = this.webgl.renderer.domElement; //this may be deprecated: incase of error try => this.webgl.render.domElement;
 		el.addEventListener('click', this.click.bind(this));
 	}
 

--- a/src/scripts/App.js
+++ b/src/scripts/App.js
@@ -30,7 +30,7 @@ export default class App {
 		window.addEventListener('resize', this.resize.bind(this));
 		window.addEventListener('keyup', this.keyup.bind(this));
 		
-		const el = this.webgl.renderer.domElement; //this may be deprecated: incase of error try => this.webgl.render.domElement;
+		const el = this.webgl.renderer.domElement; //this may be deprecated: incase of error try => const el = this.webgl.render.domElement;
 		el.addEventListener('click', this.click.bind(this));
 	}
 

--- a/src/scripts/App.js
+++ b/src/scripts/App.js
@@ -30,7 +30,7 @@ export default class App {
 		window.addEventListener('resize', this.resize.bind(this));
 		window.addEventListener('keyup', this.keyup.bind(this));
 		
-		const el = this.webgl.renderer.domElement;
+		const el = this.webgl.renderer.domElement; 
 		el.addEventListener('click', this.click.bind(this));
 	}
 

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -2,6 +2,8 @@ import ready from 'domready';
 
 import App from './App';
 
+//launch the app
+
 ready(() => {
 	window.app = new App();
 	window.app.init();


### PR DESCRIPTION
deprecated renderer
found errors using renderer.domElement () thus used  render.domElement

may not work for everyone but will on VScode 2022